### PR TITLE
Fix pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,13 +18,6 @@
         <kotlin.version>1.5.31</kotlin.version>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>mavenCentral</id>
-            <url>https://repo1.maven.org/maven2/</url>
-        </repository>
-    </repositories>
-
     <build>
         <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
         <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
@@ -61,23 +54,39 @@
                 <version>2.22.2</version>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>1.6.0</version>
-                <configuration>
-                    <mainClass>WebgameRankingParserKt</mainClass>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.0</version>
-                <configuration>
-                    <archive>
-                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                    </archive>
-                </configuration>
-            </plugin>
+		    <groupId>org.apache.maven.plugins</groupId>
+		    <artifactId>maven-dependency-plugin</artifactId>
+		    <version>2.8</version>
+		    <executions>
+			<execution>
+			    <id>copy-dependencies</id>
+			    <phase>prepare-package</phase>
+			    <goals>
+				<goal>copy-dependencies</goal>
+			    </goals>
+			    <configuration>
+			        <includeScope>runtime</includeScope>
+				<outputDirectory>
+				    ${project.build.directory}/libs
+				</outputDirectory>
+			    </configuration>
+			</execution>
+		    </executions>
+		</plugin>
+		<plugin>
+		    <groupId>org.apache.maven.plugins</groupId>
+		    <artifactId>maven-jar-plugin</artifactId>
+		    <version>3.2.0</version>
+		    <configuration>
+			<archive>
+			    <manifest>
+				<addClasspath>true</addClasspath>
+				<classpathPrefix>libs/</classpathPrefix>
+				<mainClass>WebgameRankingParser</mainClass>
+			    </manifest>
+			</archive>
+		    </configuration>
+		</plugin>
         </plugins>
     </build>
 

--- a/src/main/kotlin/META-INF/MANIFEST.MF
+++ b/src/main/kotlin/META-INF/MANIFEST.MF
@@ -1,2 +1,0 @@
-Manifest-Version: 1.0
-Main-Class: WebgameRankingParser


### PR DESCRIPTION
- Maven central neni treba deklarovat, je default
- dependency plugin kopiruje runtime zavislosti do jarka
- jar plugin sestavi manifest

Doporucuji pouzivat doporucenou package strukturu podle groupId tj. davat vsechny classy do src/main/kotlin/me/masi/